### PR TITLE
Fix for warnings on console during development

### DIFF
--- a/createLoadableVisibilityComponent.js
+++ b/createLoadableVisibilityComponent.js
@@ -16,7 +16,7 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 var trackedElements = new Map();
 var options = {
   threshold: 0,
-  rootMargin: "0px 0px 100% 0px"
+  rootMargin: "0px 0px 500px 0px"
 };
 
 function createIntersectionObserver(intersectionObserverOptions) {
@@ -94,28 +94,28 @@ function createLoadableVisibilityComponent(args, _ref) {
     }
 
     if (LoadingComponent || props.fallback) {
-      return /*#__PURE__*/_react["default"].createElement("div", _extends({
+      return /*#__PURE__*/_react["default"].createElement("div", {
         style: {
           display: "inline-block",
           minHeight: "1px",
           minWidth: "1px"
-        }
-      }, props, {
+        } // {...props}
+        ,
         ref: visibilityElementRef
-      }), LoadingComponent ? /*#__PURE__*/_react["default"].createElement(LoadingComponent, _extends({
+      }, LoadingComponent ? /*#__PURE__*/_react["default"].createElement(LoadingComponent, _extends({
         isLoading: true
       }, props)) : props.fallback);
     }
 
-    return /*#__PURE__*/_react["default"].createElement("div", _extends({
+    return /*#__PURE__*/_react["default"].createElement("div", {
       style: {
         display: "inline-block",
         minHeight: "1px",
         minWidth: "1px"
-      }
-    }, props, {
+      } // {...props}
+      ,
       ref: visibilityElementRef
-    }));
+    });
   }
 
   LoadableVisibilityComponent[preloadFunc] = function () {

--- a/createLoadableVisibilityComponent.js
+++ b/createLoadableVisibilityComponent.js
@@ -16,7 +16,7 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 var trackedElements = new Map();
 var options = {
   threshold: 0,
-  rootMargin: "0px 0px 500px 0px"
+  rootMargin: "0px 0px 100% 0px"
 };
 
 function createIntersectionObserver(intersectionObserverOptions) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-loadable-visibility",
-  "version": "3.0.2",
+  "version": "4.0.2",
   "description": "A wrapper around react-loadable for elements that are visible on the page",
   "main": "index.js",
   "repository": "https://github.com/stratiformltd/react-loadable-visibility",

--- a/src/createLoadableVisibilityComponent.js
+++ b/src/createLoadableVisibilityComponent.js
@@ -91,7 +91,7 @@ function createLoadableVisibilityComponent(
             minHeight: "1px",
             minWidth: "1px"
           }}
-          {...props}
+          // {...props}
           ref={visibilityElementRef}
         >
           {LoadingComponent
@@ -107,7 +107,7 @@ function createLoadableVisibilityComponent(
     return (
       <div
         style={{ display: "inline-block", minHeight: "1px", minWidth: "1px" }}
-        {...props}
+        // {...props}
         ref={visibilityElementRef}
       />
     );


### PR DESCRIPTION
Issue: [Props being passed to DOM as is, causing warnings during development](https://github.com/trinachoudhury1mg/react-loadable-visibility/issues/6)

Fix: Props were being passed to placeholder divs which were not being recognised on the DOM. So, commented the props object being passed.