### PR TITLE
Change fallback priority order

### DIFF
--- a/src/createLoadableVisibilityComponent.js
+++ b/src/createLoadableVisibilityComponent.js
@@ -86,12 +86,12 @@ function createLoadableVisibilityComponent(
         if (LoadingComponent || props.fallback) {
             return (
                 <div ref={visibilityElementRef} data-testid={props?.dataTestId}>
-                    {LoadingComponent
-                        ? React.createElement(LoadingComponent, {
+                    {props.fallback
+                        ? props.fallback
+                        : React.createElement(LoadingComponent, {
                               isLoading: true,
                               ...props,
-                          })
-                        : props.fallback}
+                          })}
                 </div>
             );
         }


### PR DESCRIPTION
Loadable gives priority to fallback passed as prop over fallback passed as opts however our library was giving priority to fallback opts over the fallback prop. This has been fixed in this PR. 
Fallback prop is given priority over fallback opts